### PR TITLE
[Fix] cli_demo_multi_gpus.py crashes with ValueError: empty separator on response.split("")

### DIFF
--- a/basic_demo/cli_demo_multi_gpus.py
+++ b/basic_demo/cli_demo_multi_gpus.py
@@ -107,7 +107,6 @@ while True:
         with torch.no_grad():
             outputs = model.generate(**inputs, **gen_kwargs)
             outputs = outputs[:, inputs['input_ids'].shape[1]:]
-            response = tokenizer.decode(outputs[0])
-            response = response.split("")[0]
+            response = tokenizer.decode(outputs[0], skip_special_tokens=True)
             print("\nCogVLM2:", response)
         history.append((query, response))


### PR DESCRIPTION
## Motivation

`basic_demo/cli_demo_multi_gpus.py` crashes on the very first model response with `ValueError: empty separator`.

## Root cause

Line 111 is `response = response.split("")[0]`. `str.split("")` with an empty separator raises `ValueError: empty separator`, so the multi-GPU demo fails 100% of the time. (Per git history, the original `response.split("<|end_of_text|>")[0]` lost its literal in a later edit.) The sibling `basic_demo/cli_demo.py` instead decodes with `skip_special_tokens=True` and performs no manual split.

## Modifications

`basic_demo/cli_demo_multi_gpus.py`: decode with `skip_special_tokens=True` and remove the `response.split("")[0]` line, matching `basic_demo/cli_demo.py`.

## Duplicate-check

- Track A — enumerated all open and closed PRs (`pulls?state=all --paginate`); none touch `basic_demo/cli_demo_multi_gpus.py`.
- Track B — no open issue or comment claims a fix for this file.
